### PR TITLE
use MultiGzDecoder instead of GzDecoder

### DIFF
--- a/kmer_fa/src/lib.rs
+++ b/kmer_fa/src/lib.rs
@@ -3,7 +3,7 @@ extern crate flate2;
 use std::collections::HashMap;
 use std::io;
 use std::io::prelude::*;
-use flate2::read::GzDecoder;
+use flate2::read::MultiGzDecoder;
 use std::fs::File;
 
 //add a fasta to kmer bloom filter
@@ -71,7 +71,7 @@ pub fn kmers_from_fq(
     let mut f = File::open(filename).expect("file not found");
     let mut map = HashMap::new();
     let mut line_count = 1;
-    let d = GzDecoder::new(f);
+    let d = MultiGzDecoder::new(f);
     for line in io::BufReader::new(d).lines() {
         let l = line.unwrap();
         let length_l = l.len();


### PR DESCRIPTION
sometimes fastq.gz files seem to be not properly formatted; and as explained in the flate2 docs: 'A gzip member consists of a header, compressed data and a trailer. The gzip specification, however, allows multiple gzip members to be joined in a single stream.  MultiGzDecoder will decode all consecutive members while GzDecoder will only decompress the first gzip member. The multistream format is commonly used in bioinformatics, for example when using the BGZF compressed data.' Fastq.gz from Illumina appear to be in multistream format! 